### PR TITLE
Add binary serialization to Communication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
 name = "serialize_hierarchy"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "color-eyre",
  "nalgebra",
  "serde",
@@ -3828,6 +3829,7 @@ name = "types"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "bincode",
  "color-eyre",
  "image",
  "nalgebra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,11 +3200,11 @@ name = "serialize_hierarchy"
 version = "0.1.0"
 dependencies = [
  "bincode",
- "color-eyre",
  "nalgebra",
  "serde",
  "serde_json",
  "serialize_hierarchy_derive",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,7 +3829,6 @@ name = "types"
 version = "0.1.0"
 dependencies = [
  "approx",
- "bincode",
  "color-eyre",
  "image",
  "nalgebra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3144,6 +3144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3162,6 +3171,15 @@ checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3611210d2d67e3513204742004d6ac6f589e521861dabb0f649b070eea8bed9e"
+dependencies = [
  "serde",
 ]
 
@@ -3819,7 +3837,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
+ "serde_bytes",
  "serde_json",
+ "serde_test",
  "serialize_hierarchy",
  "spl_network_messages",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,9 @@ rmp-serde = "1.1.1"
 rust-ini = "0.18.0"
 rustfft = "6.0.1"
 serde = { version = "1.0.145", features = ["derive", "rc"] }
-serde_json = "1.0.85"
+serde_bytes = "0.11.8"
+serde_json = "1.0.91"
+serde_test = "1.0.152"
 serialize_hierarchy = { path = "crates/serialize_hierarchy" }
 serialize_hierarchy_derive = { path = "crates/serialize_hierarchy_derive" }
 smallvec = "1.9.0"

--- a/crates/communication/src/messages.rs
+++ b/crates/communication/src/messages.rs
@@ -20,10 +20,7 @@ pub enum Request {
 pub enum Response {
     Textual(TextualResponse),
     Binary(BinaryResponse),
-    Close {
-        code: CloseCode,
-        reason: Reason,
-    },
+    Close { code: CloseCode, reason: Reason },
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/communication/src/messages.rs
+++ b/crates/communication/src/messages.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -7,7 +7,6 @@ use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 pub type CyclerInstance = String;
 pub type Path = String;
 pub type Reason = String;
-pub type Type = String;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Request {
@@ -63,7 +62,7 @@ pub enum OutputRequest {
 pub enum TextualOutputResponse {
     GetFields {
         id: usize,
-        fields: BTreeMap<CyclerInstance, BTreeMap<Path, Type>>,
+        fields: BTreeMap<CyclerInstance, BTreeSet<Path>>,
     },
     GetNext {
         id: usize,
@@ -139,7 +138,7 @@ pub enum ParameterRequest {
 pub enum ParameterResponse {
     GetHierarchy {
         id: usize,
-        hierarchy: BTreeMap<Path, String>,
+        hierarchy: BTreeSet<Path>,
     },
     GetCurrent {
         id: usize,

--- a/crates/communication/src/messages.rs
+++ b/crates/communication/src/messages.rs
@@ -19,7 +19,6 @@ pub enum Request {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Response {
     Textual(TextualResponse),
-    #[allow(dead_code)] // TODO
     Binary(BinaryResponse),
     Close {
         code: CloseCode,

--- a/crates/communication/src/server/outputs/mod.rs
+++ b/crates/communication/src/server/outputs/mod.rs
@@ -52,7 +52,6 @@ impl Eq for Client {}
 #[derive(Debug)]
 struct Subscription {
     pub path: Path,
-    #[allow(dead_code)] // TODO
     pub format: Format,
     pub once: bool,
 }

--- a/crates/communication/src/server/outputs/mod.rs
+++ b/crates/communication/src/server/outputs/mod.rs
@@ -1,11 +1,11 @@
 use std::{
-    collections::BTreeMap,
+    collections::BTreeSet,
     hash::{Hash, Hasher},
 };
 
 use tokio::sync::mpsc::Sender;
 
-use crate::messages::{Format, OutputRequest, Path, Response, Type};
+use crate::messages::{Format, OutputRequest, Path, Response};
 
 pub mod provider;
 pub mod router;
@@ -15,7 +15,7 @@ pub enum Request {
     ClientRequest(ClientRequest),
     RegisterCycler {
         cycler_instance: String,
-        fields: BTreeMap<Path, Type>,
+        fields: BTreeSet<Path>,
         request_sender: Sender<ClientRequest>,
     },
 }

--- a/crates/communication/src/server/outputs/provider.rs
+++ b/crates/communication/src/server/outputs/provider.rs
@@ -48,7 +48,7 @@ where
         drop(outputs_sender);
 
         let mut subscriptions = HashMap::new();
-        let mut next_binary_reference_id = Wrapping(0_usize);
+        let mut next_binary_reference_id = Wrapping(0);
         loop {
             let subscriptions_state = select! {
                 request = request_receiver.recv() => {

--- a/crates/communication/src/server/outputs/router.rs
+++ b/crates/communication/src/server/outputs/router.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map::Entry, BTreeMap, HashMap};
+use std::collections::{hash_map::Entry, BTreeSet, HashMap};
 
 use tokio::{
     spawn,
@@ -6,9 +6,7 @@ use tokio::{
     task::JoinHandle,
 };
 
-use crate::messages::{
-    OutputRequest, Path, Response, TextualOutputResponse, TextualResponse, Type,
-};
+use crate::messages::{OutputRequest, Path, Response, TextualOutputResponse, TextualResponse};
 
 use super::{Client, ClientRequest, Request};
 
@@ -41,7 +39,7 @@ pub fn router(mut request_receiver: Receiver<Request>) -> JoinHandle<()> {
 
 async fn handle_request(
     request: ClientRequest,
-    request_channels_of_cyclers: &HashMap<String, (BTreeMap<Path, Type>, Sender<ClientRequest>)>,
+    request_channels_of_cyclers: &HashMap<String, (BTreeSet<Path>, Sender<ClientRequest>)>,
     cached_cycler_instances: &mut HashMap<(Client, usize), String>,
 ) {
     match &request.request {
@@ -190,7 +188,7 @@ mod tests {
         let router_task = router(request_receiver);
 
         let cycler_instance = "CyclerInstance";
-        let fields: BTreeMap<String, String> = [("a.b.c".to_string(), "bool".to_string())].into();
+        let fields: BTreeSet<String> = ["a.b.c".to_string()].into();
         let (provider_request_sender, _provider_request_receiver) = channel(1);
         request_sender
             .send(Request::RegisterCycler {

--- a/crates/communication/src/server/runtime.rs
+++ b/crates/communication/src/server/runtime.rs
@@ -113,14 +113,14 @@ impl Runtime {
         self.join_handle.join()
     }
 
-    pub fn register_cycler_instance<Output>(
+    pub fn register_cycler_instance<Outputs>(
         &self,
         cycler_instance: &'static str,
         outputs_changed: Arc<Notify>,
-        outputs_reader: Reader<Output>,
+        outputs_reader: Reader<Outputs>,
         subscribed_outputs_writer: Writer<HashSet<String>>,
     ) where
-        Output: SerializeHierarchy + Send + Sync + 'static,
+        Outputs: SerializeHierarchy + Send + Sync + 'static,
     {
         let _guard = self.runtime.enter();
         provider(

--- a/crates/hulk/src/nao/camera.rs
+++ b/crates/hulk/src/nao/camera.rs
@@ -53,9 +53,9 @@ impl Camera {
             ])
             .wrap_err("failed to queue buffer")?;
         Ok(Image::from_raw_buffer(
-            buffer,
             self.parameters.width / 2,
             self.parameters.height,
+            buffer,
         ))
         // TODO: readd consecutive sequence number checking
     }

--- a/crates/hulk/src/webots/camera.rs
+++ b/crates/hulk/src/webots/camera.rs
@@ -82,7 +82,7 @@ impl Camera {
             320 * 480
         ];
         bgra_444_to_ycbcr_422(&bgra_buffer, &mut ycbcr_buffer);
-        Ok(Image::from_ycbcr_buffer(ycbcr_buffer, 320, 480))
+        Ok(Image::from_ycbcr_buffer(320, 480, ycbcr_buffer))
     }
 }
 

--- a/crates/serialize_hierarchy/Cargo.toml
+++ b/crates/serialize_hierarchy/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "GPL-3.0-only"
 
 [dependencies]
+bincode = { workspace = true }
 color-eyre = { workspace = true }
 nalgebra = { workspace = true }
 serde = { workspace = true }

--- a/crates/serialize_hierarchy/Cargo.toml
+++ b/crates/serialize_hierarchy/Cargo.toml
@@ -6,8 +6,8 @@ license = "GPL-3.0-only"
 
 [dependencies]
 bincode = { workspace = true }
-color-eyre = { workspace = true }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serialize_hierarchy_derive = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/serialize_hierarchy/src/lib.rs
+++ b/crates/serialize_hierarchy/src/lib.rs
@@ -222,7 +222,7 @@ impl<T> SerializeHierarchy for HashSet<T> {
     }
 
     fn get_fields() -> BTreeSet<String> {
-        [String::new()].into()
+        Default::default()
     }
 }
 
@@ -258,7 +258,7 @@ impl<T> SerializeHierarchy for Vec<T> {
     }
 
     fn get_fields() -> BTreeSet<String> {
-        [String::new()].into()
+        Default::default()
     }
 }
 
@@ -296,7 +296,7 @@ macro_rules! serialize_hierarchy_primary_impl {
             }
 
             fn get_fields() -> BTreeSet<String> {
-                [String::new()].into()
+                Default::default()
             }
         }
     };
@@ -329,3 +329,40 @@ serialize_hierarchy_primary_impl!(String);
 serialize_hierarchy_primary_impl!(Range<f32>);
 serialize_hierarchy_primary_impl!(Range<Duration>);
 serialize_hierarchy_primary_impl!(PathBuf);
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use crate as serialize_hierarchy;
+
+    use super::*;
+
+    #[derive(Deserialize, Serialize, SerializeHierarchy)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    #[derive(Deserialize, Serialize, SerializeHierarchy)]
+    struct Inner {
+        field: bool,
+    }
+
+    #[test]
+    fn primitive_fields_are_empty() {
+        assert_eq!(bool::get_fields(), Default::default());
+    }
+
+    #[test]
+    fn flat_struct_fields_contain_fields() {
+        assert_eq!(Inner::get_fields(), ["field".to_string()].into());
+    }
+
+    #[test]
+    fn nested_struct_fields_contain_fields() {
+        assert_eq!(
+            Outer::get_fields(),
+            ["inner".to_string(), "inner.field".to_string()].into()
+        );
+    }
+}

--- a/crates/serialize_hierarchy_derive/src/process_enum.rs
+++ b/crates/serialize_hierarchy_derive/src/process_enum.rs
@@ -3,35 +3,47 @@ use syn::{DataEnum, DeriveInput};
 
 pub fn process_enum(input: &DeriveInput, _data: &DataEnum) -> proc_macro::TokenStream {
     let name = &input.ident;
+    let name_string = name.to_string();
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let expanded = quote! {
+    quote! {
         impl #impl_generics serialize_hierarchy::SerializeHierarchy for #name #ty_generics #where_clause {
-            fn serialize_hierarchy(
+            fn serialize_path<S>(
                 &self,
-                field_path: &str,
-                format: serialize_hierarchy::Format,
-            ) -> color_eyre::Result<serialize_hierarchy::SerializedValue> {
-                color_eyre::eyre::bail!("Cannot access enum with path `{}`", field_path)
+                path: &str,
+            ) -> Result<S::Serialized, serialize_hierarchy::Error<S::Error>>
+            where
+                S: serialize_hierarchy::Serializer,
+                S::Error: std::error::Error,
+            {
+                Err(serialize_hierarchy::Error::TypeDoesNotSupportSerialization {
+                    type_name: #name_string,
+                    path: path.to_string(),
+                })
             }
 
-            fn deserialize_hierarchy(
+            fn deserialize_path<S>(
                 &mut self,
-                field_path: &str,
-                data: serialize_hierarchy::SerializedValue,
-            ) -> color_eyre::Result<()> {
-                color_eyre::eyre::bail!("Cannot access enum with path `{}`", field_path)
+                path: &str,
+                _data: S::Serialized,
+            ) -> Result<(), serialize_hierarchy::Error<S::Error>>
+            where
+                S: serialize_hierarchy::Serializer,
+                S::Error: std::error::Error,
+            {
+                Err(serialize_hierarchy::Error::TypeDoesNotSupportDeserialization {
+                    type_name: #name_string,
+                    path: path.to_string(),
+                })
             }
 
-            fn exists(field_path: &str) -> bool {
+            fn exists(_path: &str) -> bool {
                 false
             }
 
-            fn get_hierarchy() -> serialize_hierarchy::HierarchyType {
-                serialize_hierarchy::HierarchyType::GenericEnum
+            fn get_fields() -> std::collections::BTreeSet<String> {
+                [std::string::String::new()].into()
             }
         }
-    };
-
-    expanded.into()
+    }.into()
 }

--- a/crates/serialize_hierarchy_derive/src/process_enum.rs
+++ b/crates/serialize_hierarchy_derive/src/process_enum.rs
@@ -9,15 +9,16 @@ pub fn process_enum(input: &DeriveInput, _data: &DataEnum) -> proc_macro::TokenS
         impl #impl_generics serialize_hierarchy::SerializeHierarchy for #name #ty_generics #where_clause {
             fn serialize_hierarchy(
                 &self,
-                field_path: &str
-            ) -> color_eyre::Result<serialize_hierarchy::serde_json::Value> {
+                field_path: &str,
+                format: serialize_hierarchy::Format,
+            ) -> color_eyre::Result<serialize_hierarchy::SerializedValue> {
                 color_eyre::eyre::bail!("Cannot access enum with path `{}`", field_path)
             }
 
             fn deserialize_hierarchy(
                 &mut self,
                 field_path: &str,
-                data: serialize_hierarchy::serde_json::Value
+                data: serialize_hierarchy::SerializedValue,
             ) -> color_eyre::Result<()> {
                 color_eyre::eyre::bail!("Cannot access enum with path `{}`", field_path)
             }

--- a/crates/serialize_hierarchy_derive/src/process_struct.rs
+++ b/crates/serialize_hierarchy_derive/src/process_struct.rs
@@ -83,7 +83,7 @@ pub fn process_struct(input: &DeriveInput, data: &DataStruct) -> proc_macro::Tok
             }
 
             fn get_fields() -> std::collections::BTreeSet<String> {
-                std::iter::once(String::new())
+                std::iter::empty::<std::string::String>()
                     #(#field_chains)*
                     .collect()
             }
@@ -239,6 +239,7 @@ fn generate_field_chains(fields: &Fields) -> Vec<TokenStream> {
                 return None;
             }
             let name = field.ident.as_ref().unwrap();
+            let name_string = name.to_string();
             let pattern = format!("{}.{{}}", name);
             let field_type = if let Type::Path(type_path) = &field.ty {
                 let mut type_path = type_path.clone();
@@ -252,6 +253,7 @@ fn generate_field_chains(fields: &Fields) -> Vec<TokenStream> {
                 field.ty.to_token_stream()
             };
             Some(quote! {
+                .chain(std::iter::once(#name_string.to_string()))
                 .chain(
                     #field_type::get_fields()
                         .into_iter()

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -6,6 +6,7 @@ license = "GPL-3.0-only"
 
 [dependencies]
 approx = { workspace = true }
+bincode = { workspace = true }
 color-eyre = { workspace = true }
 image = { workspace = true }
 nalgebra = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -12,7 +12,9 @@ nalgebra = { workspace = true }
 ordered-float = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
 serde_json = { workspace = true }
+serde_test = { workspace = true }
 serialize_hierarchy = { workspace = true }
 spl_network_messages = { workspace = true }
 tokio = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -6,7 +6,6 @@ license = "GPL-3.0-only"
 
 [dependencies]
 approx = { workspace = true }
-bincode = { workspace = true }
 color-eyre = { workspace = true }
 image = { workspace = true }
 nalgebra = { workspace = true }

--- a/crates/types/src/geometry.rs
+++ b/crates/types/src/geometry.rs
@@ -2,8 +2,7 @@ use approx::{AbsDiffEq, RelativeEq};
 use color_eyre::{eyre::bail, Result};
 use nalgebra::{distance, vector, Point2, UnitComplex, Vector2};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use serialize_hierarchy::{HierarchyType, SerializeHierarchy};
+use serialize_hierarchy::{Format, HierarchyType, SerializeHierarchy, SerializedValue};
 
 use std::f32::consts::PI;
 
@@ -200,11 +199,11 @@ impl LineSegment {
 pub struct TwoLineSegments(pub LineSegment, pub LineSegment);
 
 impl SerializeHierarchy for TwoLineSegments {
-    fn serialize_hierarchy(&self, field_path: &str) -> Result<Value> {
+    fn serialize_hierarchy(&self, field_path: &str, _format: Format) -> Result<SerializedValue> {
         bail!("cannot access TwoLineSegments with path: {}", field_path)
     }
 
-    fn deserialize_hierarchy(&mut self, field_path: &str, _data: Value) -> Result<()> {
+    fn deserialize_hierarchy(&mut self, field_path: &str, _data: SerializedValue) -> Result<()> {
         bail!("cannot access TwoLineSegments with path: {}", field_path)
     }
 

--- a/crates/types/src/geometry.rs
+++ b/crates/types/src/geometry.rs
@@ -1,10 +1,9 @@
 use approx::{AbsDiffEq, RelativeEq};
-use color_eyre::{eyre::bail, Result};
 use nalgebra::{distance, vector, Point2, UnitComplex, Vector2};
 use serde::{Deserialize, Serialize};
-use serialize_hierarchy::{Format, HierarchyType, SerializeHierarchy, SerializedValue};
+use serialize_hierarchy::{Error, SerializeHierarchy, Serializer};
 
-use std::f32::consts::PI;
+use std::{collections::BTreeSet, error, f32::consts::PI};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Orientation {
@@ -199,20 +198,38 @@ impl LineSegment {
 pub struct TwoLineSegments(pub LineSegment, pub LineSegment);
 
 impl SerializeHierarchy for TwoLineSegments {
-    fn serialize_hierarchy(&self, field_path: &str, _format: Format) -> Result<SerializedValue> {
-        bail!("cannot access TwoLineSegments with path: {}", field_path)
+    fn serialize_path<S>(&self, path: &str) -> Result<S::Serialized, Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        Err(Error::TypeDoesNotSupportSerialization {
+            type_name: "TwoLineSegments",
+            path: path.to_string(),
+        })
     }
 
-    fn deserialize_hierarchy(&mut self, field_path: &str, _data: SerializedValue) -> Result<()> {
-        bail!("cannot access TwoLineSegments with path: {}", field_path)
+    fn deserialize_path<S>(
+        &mut self,
+        path: &str,
+        _data: S::Serialized,
+    ) -> Result<(), Error<S::Error>>
+    where
+        S: Serializer,
+        S::Error: error::Error,
+    {
+        Err(Error::TypeDoesNotSupportDeserialization {
+            type_name: "TwoLineSegments",
+            path: path.to_string(),
+        })
     }
 
-    fn exists(_field_path: &str) -> bool {
-        true
+    fn exists(_path: &str) -> bool {
+        false
     }
 
-    fn get_hierarchy() -> HierarchyType {
-        HierarchyType::GenericStruct
+    fn get_fields() -> BTreeSet<String> {
+        [String::new()].into()
     }
 }
 

--- a/crates/types/src/image.rs
+++ b/crates/types/src/image.rs
@@ -309,7 +309,7 @@ impl<'de> Deserialize<'de> for Image {
             Width422,
             Height,
         }
-        const FIELDS: &'static [&'static str] = &["buffer", "width_422", "height"];
+        const FIELDS: &[&str] = &["buffer", "width_422", "height"];
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -526,7 +526,7 @@ mod tests {
             &image.compact(),
             &[
                 Token::NewtypeStruct {
-                    name: "TestingImageWrapper",
+                    name: "ImageTestingWrapper",
                 },
                 Token::Struct {
                     name: "Image",
@@ -560,7 +560,7 @@ mod tests {
             &image.readable(),
             &[
                 Token::NewtypeStruct {
-                    name: "TestingImageWrapper",
+                    name: "ImageTestingWrapper",
                 },
                 Token::Struct {
                     name: "Image",

--- a/crates/types/src/image.rs
+++ b/crates/types/src/image.rs
@@ -41,7 +41,7 @@ impl Debug for Image {
         impl Debug for DebugBuffer {
             fn fmt(&self, formatter: &mut Formatter<'_>) -> Result<(), fmt::Error> {
                 formatter.write_fmt(format_args!(
-                    "[{} element{}]",
+                    "[{} pixel{}]",
                     self.buffer_length,
                     match self.buffer_length {
                         0 => "s",

--- a/crates/vision/src/image_segmenter.rs
+++ b/crates/vision/src/image_segmenter.rs
@@ -577,14 +577,14 @@ mod tests {
     #[test]
     fn image_vertical_color_three_pixels() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            3,
             vec![
                 // only evaluating every second 422 pixel
                 YCbCr422::new(0, 10, 10, 10),
                 YCbCr422::new(0, 15, 14, 13),
                 YCbCr422::new(0, 10, 10, 10),
             ],
-            1,
-            3,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -615,6 +615,8 @@ mod tests {
     #[test]
     fn image_vertical_color_twelve_pixels() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            12,
             vec![
                 YCbCr422::new(0, 10, 10, 10),
                 YCbCr422::new(0, 10, 10, 10),
@@ -629,8 +631,6 @@ mod tests {
                 YCbCr422::new(0, 10, 10, 10),
                 YCbCr422::new(0, 10, 10, 10),
             ],
-            1,
-            12,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -661,6 +661,8 @@ mod tests {
     #[test]
     fn image_with_three_vertical_increasing_segments_without_median() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            12,
             vec![
                 // only evaluating every secondth pixel
                 YCbCr422::new(0, 0, 0, 0),
@@ -680,8 +682,6 @@ mod tests {
 
                                            // segment boundary will be here
             ],
-            1,
-            12,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -724,6 +724,8 @@ mod tests {
     #[test]
     fn image_with_three_vertical_increasing_segments_with_median() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            12,
             vec![
                 // only evaluating every second pixel
                 YCbCr422::new(0, 0, 0, 0),
@@ -742,8 +744,6 @@ mod tests {
                 YCbCr422::new(3, 0, 0, 0), // skipped
                                            // segment boundary will be here
             ],
-            1,
-            12,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -798,6 +798,8 @@ mod tests {
     #[test]
     fn image_with_three_vertical_decreasing_segments_without_median() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            12,
             vec![
                 // only evaluating every secondth 422 pixel
                 YCbCr422::new(3, 0, 0, 0),
@@ -817,8 +819,6 @@ mod tests {
 
                                            // segment boundary will be here
             ],
-            1,
-            12,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -867,6 +867,8 @@ mod tests {
     #[test]
     fn image_with_three_vertical_decreasing_segments_with_median() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            12,
             vec![
                 // only evaluating every secondth 422 pixel
                 YCbCr422::new(3, 0, 0, 0),
@@ -886,8 +888,6 @@ mod tests {
 
                                            // segment boundary will be here
             ],
-            1,
-            12,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -942,6 +942,8 @@ mod tests {
     #[test]
     fn image_with_three_vertical_segments_with_higher_differences_without_median() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            44,
             vec![
                 // only evaluating every secondth 422 pixel
                 YCbCr422::new(0, 0, 0, 0),
@@ -993,8 +995,6 @@ mod tests {
 
                                            // segment boundary will be here
             ],
-            1,
-            44,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -1084,6 +1084,8 @@ mod tests {
     #[test]
     fn image_with_three_vertical_segments_with_higher_differences_with_median() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            44,
             vec![
                 // only evaluating every secondth 422 pixel
                 YCbCr422::new(0, 0, 0, 0),
@@ -1135,8 +1137,6 @@ mod tests {
 
                                            // segment boundary will be here
             ],
-            1,
-            44,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -1270,6 +1270,8 @@ mod tests {
     #[test]
     fn image_with_one_vertical_segment_with_increasing_differences_without_median() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            16,
             vec![
                 // only evaluating every secondth 422 pixel
                 YCbCr422::new(0, 0, 0, 0),
@@ -1291,8 +1293,6 @@ mod tests {
 
                                             // segment boundary will be here
             ],
-            1,
-            16,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,
@@ -1335,6 +1335,8 @@ mod tests {
     #[test]
     fn image_with_one_vertical_segment_with_increasing_differences_with_median() {
         let image = Image::from_ycbcr_buffer(
+            1,
+            16,
             vec![
                 // only evaluating every secondth 422 pixel
                 YCbCr422::new(0, 0, 0, 0),
@@ -1356,8 +1358,6 @@ mod tests {
 
                                             // segment boundary will be here
             ],
-            1,
-            16,
         );
         let field_color = FieldColor {
             red_chromaticity_threshold: 0.37,

--- a/crates/vision/src/line_detection.rs
+++ b/crates/vision/src/line_detection.rs
@@ -365,7 +365,7 @@ mod tests {
                     }
                 }
             }
-            Image::from_ycbcr_buffer(buffer, width_422, height)
+            Image::from_ycbcr_buffer(width_422, height, buffer)
         }
 
         let image_size = vector![10.0, 500.0];


### PR DESCRIPTION
## Introduced Changes

What it says, this PR enables Communication to serialize binary messages from *any* given path. The `SerializeHierarchy` has been extended to support binary serialization. The communication server constructs binary messages and sends them to the client. To enable efficient image serialization, the `Image` type in this PR receives a special `Serialize` implementation s.t. it de-/serializes into/from JPEG RGB data. Test cases have been added to ensure correct execution.

## ToDo / Known Issues

None

## Ideas for Next Iterations (Not This PR)

None

## How to Test

- Execute the test cases (`types` and `communication` crates)
- Try to register a subscription with binary format and observe additional binary messages in [bincode](https://github.com/bincode-org/bincode) format according to `messages.rs`